### PR TITLE
Add shortcuts handler infrastructure

### DIFF
--- a/desktop-app/app/containers/Root.js
+++ b/desktop-app/app/containers/Root.js
@@ -58,11 +58,11 @@ export default class Root extends Component<Props> {
     initRendererShortcutManager();
     // const {store} = this.props;
     
-    // registerShortcut({id: 'ZoomIn', title: 'Zoom In', accelerators: ['CommandOrControl+numadd', 'CommandOrControl+plus']}, () => {
+    // registerShortcut({id: 'ZoomIn', title: 'Zoom In', accelerators: ['CommandOrControl+numadd', 'CommandOrControl+plus', 'CommandOrControl+Shift+=']}, () => {
     //   store.dispatch(onZoomChange(store.getState().browser.zoomLevel + 0.1))
     // });
 
-    // registerShortcut({id: 'ZoomOut', title: 'Zoom Out', accelerators: ['CommandOrControl+numsub']}, () => {
+    // registerShortcut({id: 'ZoomOut', title: 'Zoom Out', accelerators: ['CommandOrControl+numsub', 'CommandOrControl+-']}, () => {
     //   store.dispatch(onZoomChange(store.getState().browser.zoomLevel - 0.1))
     // });
 

--- a/desktop-app/app/containers/Root.js
+++ b/desktop-app/app/containers/Root.js
@@ -10,7 +10,8 @@ import {ThemeProvider} from '@material-ui/styles';
 import {grey} from '@material-ui/core/colors';
 import {themeColor} from '../constants/colors';
 import ErrorBoundary from '../components/ErrorBoundary';
-
+import {initRendererShortcutManager, registerShortcut, clearShortcuts} from '../shotcut-manager/renderer-shortcut-manager';
+import {onZoomChange} from '../actions/browser';
 type Props = {
   store: Store,
   history: {},
@@ -53,6 +54,25 @@ const getApp = history => {
 };
 
 export default class Root extends Component<Props> {
+  componentDidMount() {
+    initRendererShortcutManager();
+    const {store} = this.props;
+    
+    registerShortcut({id: 'ZoomIn', title: 'Zoom In', accelerator: 'CommandOrControl+numadd'}, () => {
+      store.dispatch(onZoomChange(store.getState().browser.zoomLevel + 0.1))
+    });
+
+    registerShortcut({id: 'ZoomOut', title: 'Zoom Out', accelerator: 'CommandOrControl+numsub'}, () => {
+      store.dispatch(onZoomChange(store.getState().browser.zoomLevel - 0.1))
+    });
+
+    registerShortcut({id: 'ZoomReset', title: 'Zoom Reset', accelerator: 'CommandOrControl+num0'}, () => {
+      store.dispatch(onZoomChange(0.6))
+    });
+  }
+  componentWillUnmount() {
+    clearShortcuts();
+  }
   render() {
     const {store, history} = this.props;
     return (

--- a/desktop-app/app/containers/Root.js
+++ b/desktop-app/app/containers/Root.js
@@ -56,19 +56,19 @@ const getApp = history => {
 export default class Root extends Component<Props> {
   componentDidMount() {
     initRendererShortcutManager();
-    const {store} = this.props;
+    // const {store} = this.props;
     
-    registerShortcut({id: 'ZoomIn', title: 'Zoom In', accelerators: ['CommandOrControl+numadd', 'CommandOrControl+plus']}, () => {
-      store.dispatch(onZoomChange(store.getState().browser.zoomLevel + 0.1))
-    });
+    // registerShortcut({id: 'ZoomIn', title: 'Zoom In', accelerators: ['CommandOrControl+numadd', 'CommandOrControl+plus']}, () => {
+    //   store.dispatch(onZoomChange(store.getState().browser.zoomLevel + 0.1))
+    // });
 
-    registerShortcut({id: 'ZoomOut', title: 'Zoom Out', accelerators: ['CommandOrControl+numsub']}, () => {
-      store.dispatch(onZoomChange(store.getState().browser.zoomLevel - 0.1))
-    });
+    // registerShortcut({id: 'ZoomOut', title: 'Zoom Out', accelerators: ['CommandOrControl+numsub']}, () => {
+    //   store.dispatch(onZoomChange(store.getState().browser.zoomLevel - 0.1))
+    // });
 
-    registerShortcut({id: 'ZoomReset', title: 'Zoom Reset', accelerators: ['CommandOrControl+num0', 'CommandOrControl+0']}, () => {
-      store.dispatch(onZoomChange(0.6))
-    });
+    // registerShortcut({id: 'ZoomReset', title: 'Zoom Reset', accelerators: ['CommandOrControl+num0', 'CommandOrControl+0']}, () => {
+    //   store.dispatch(onZoomChange(0.6))
+    // });
   }
 
   componentWillUnmount() {

--- a/desktop-app/app/containers/Root.js
+++ b/desktop-app/app/containers/Root.js
@@ -58,21 +58,23 @@ export default class Root extends Component<Props> {
     initRendererShortcutManager();
     const {store} = this.props;
     
-    registerShortcut({id: 'ZoomIn', title: 'Zoom In', accelerator: 'CommandOrControl+numadd'}, () => {
+    registerShortcut({id: 'ZoomIn', title: 'Zoom In', accelerators: ['CommandOrControl+numadd', 'CommandOrControl+plus']}, () => {
       store.dispatch(onZoomChange(store.getState().browser.zoomLevel + 0.1))
     });
 
-    registerShortcut({id: 'ZoomOut', title: 'Zoom Out', accelerator: 'CommandOrControl+numsub'}, () => {
+    registerShortcut({id: 'ZoomOut', title: 'Zoom Out', accelerators: ['CommandOrControl+numsub']}, () => {
       store.dispatch(onZoomChange(store.getState().browser.zoomLevel - 0.1))
     });
 
-    registerShortcut({id: 'ZoomReset', title: 'Zoom Reset', accelerator: 'CommandOrControl+num0'}, () => {
+    registerShortcut({id: 'ZoomReset', title: 'Zoom Reset', accelerators: ['CommandOrControl+num0', 'CommandOrControl+0']}, () => {
       store.dispatch(onZoomChange(0.6))
     });
   }
+
   componentWillUnmount() {
     clearShortcuts();
   }
+
   render() {
     const {store, history} = this.props;
     return (

--- a/desktop-app/app/main.dev.js
+++ b/desktop-app/app/main.dev.js
@@ -25,6 +25,7 @@ import installExtension, {
 import devtron from 'devtron';
 import fs from 'fs';
 import {migrateDeviceSchema} from './settings/migration';
+import {initMainShortcutManager} from './shotcut-manager/main-shortcut-manager';
 
 const path = require('path');
 
@@ -188,6 +189,8 @@ const createWindow = async () => {
       `);
     }
   });
+
+  initMainShortcutManager(mainWindow);
 
   mainWindow.once('ready-to-show', () => {
     if (urlToOpen) {

--- a/desktop-app/app/menu.js
+++ b/desktop-app/app/menu.js
@@ -85,7 +85,7 @@ export default class MenuBuilder {
           });
 
           win.on('blur', () => {
-             win.hide();
+            win.hide();
           });
 
           win.on('closed', () => {

--- a/desktop-app/app/menu.js
+++ b/desktop-app/app/menu.js
@@ -10,6 +10,7 @@ import {
 } from 'electron';
 import * as os from 'os';
 import {pkg} from './utils/generalUtils';
+import {getAllShortcuts} from './shotcut-manager/main-shortcut-manager';
 
 const path = require('path');
 
@@ -68,6 +69,7 @@ export default class MenuBuilder {
             webPreferences: {
               devTools: false,
               nodeIntegration: true,
+              additionalArguments: [JSON.stringify(getAllShortcuts())]
             },
           });
 
@@ -83,7 +85,7 @@ export default class MenuBuilder {
           });
 
           win.on('blur', () => {
-            win.hide();
+             win.hide();
           });
 
           win.on('closed', () => {

--- a/desktop-app/app/shortcuts.html
+++ b/desktop-app/app/shortcuts.html
@@ -106,9 +106,9 @@
       let registeredShortcuts = [];
       try {
         registeredShortcuts = JSON.parse(window.process.argv.slice(-1)).reduce((arr, def) => {
-        arr.push([def.title, mapAccelerator(def.accelerators[0])]);
-        def.accelerators.slice(1).forEach(acc => arr.push(['', mapAccelerator(acc)]))
-        return arr;
+          arr.push([def.title, mapAccelerator(def.accelerators[0])]);
+          def.accelerators.slice(1).forEach(acc => arr.push(['', mapAccelerator(acc)]))
+          return arr;
         }, []);
       } catch { }
 

--- a/desktop-app/app/shortcuts.html
+++ b/desktop-app/app/shortcuts.html
@@ -1,117 +1,165 @@
 <html>
-  <head>
-    <link rel="stylesheet" type="text/css" href="app.global.css" />
-    <style>
-      body {
-        background-color: #1e1e1e;
-        color: white;
-        display: flex;
-        justify-content: space-between;
-        flex-direction: column;
-        font-family: 'Roboto', sans-serif;
-      }
-      ul {
-        margin: 20px 50px;
-      }
-      li {
-        display: flex;
-        flex-direction: row;
-        flex-wrap: wrap;
-        align-items: center;
-        padding: 5px;
-      }
-      .header {
-        font-size: 2em;
-        display: flex;
-        justify-content: center;
-        margin: 100px 0 50px;
-      }
-      .label {
-        width: 250px;
-        font-size: large;
-      }
-      .key {
-        display: flex;
-        text-align: right;
-        padding: 7px;
-        margin: 0 10px;
-        justify-content: center;
-        align-items: center;
-        font-size: large;
-        background-color: black;
-        border-radius: 5px;
-      }
-      .btn-wrapper {
-        display: flex;
-        justify-content: center;
-        background-color: transparent;
-        padding-bottom: 50px;
-      }
-      #close-btn {
-        font-family: 'Roboto', sans-serif;
-        font-size: x-large;
-        padding: 10 20 10 20px;
-        border: 0;
-        border-radius: 5px;
-        background-color: black;
-        color: white;
-        cursor: pointer;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="header">Keyboard Shortcuts</div>
-    <ul id="list"></ul>
-    <div class="btn-wrapper">
-      <button id="close-btn">Close</button>
-    </div>
-    <script>
-      const shortcuts = [
-        ['Open HTML File', ['Cmd/Ctrl', 'O']],
-        ['Reload', ['Cmd/Ctrl', 'R']],
-        ['Reload Ignoring Cache', ['Cmd/Ctrl', 'Shift', 'R']],
-        ['Reload CSS Files In-place', ['Alt', 'R']],
-      ];
+	<head>
+	  <link rel="stylesheet" type="text/css" href="app.global.css" />
+	  <style>
+		body {
+		  background-color: #1e1e1e;
+		  color: white;
+		  display: flex;
+		  justify-content: space-between;
+		  flex-direction: column;
+		  font-family: 'Roboto', sans-serif;
+		}
+		ul {
+		  margin: 20px 50px;
+		  overflow-y: auto;
+		}
+		li {
+		  display: flex;
+		  flex-direction: row;
+		  flex-wrap: wrap;
+		  align-items: center;
+		  padding: 5px;
+		}
+		.header {
+		  font-size: 2em;
+		  display: flex;
+		  justify-content: center;
+		  margin: 100px 0 50px;
+		}
+		.label {
+		  width: 250px;
+		  font-size: large;
+		}
+		.key {
+		  display: flex;
+		  text-align: right;
+		  padding: 7px;
+		  margin: 0 10px;
+		  justify-content: center;
+		  align-items: center;
+		  font-size: large;
+		  background-color: black;
+		  border-radius: 5px;
+		  font-family: "Consolas", "Courier New", monospace;
+		  white-space: pre;
+		}
+		.btn-wrapper {
+		  display: flex;
+		  justify-content: center;
+		  background-color: transparent;
+		  padding-bottom: 50px;
+		}
+		#close-btn {
+		  font-family: 'Roboto', sans-serif;
+		  font-size: x-large;
+		  padding: 10 20 10 20px;
+		  border: 0;
+		  border-radius: 5px;
+		  background-color: black;
+		  color: white;
+		  cursor: pointer;
+		}
+	  </style>
+	</head>
+	<body>
+	  <div class="header">Keyboard Shortcuts</div>
+	  <ul id="list"></ul>
+	  <div class="btn-wrapper">
+		<button id="close-btn">Close</button>
+	  </div>
+	  <script>
+		function firstToUpperCase(s) {
+		  return s[0].toUpperCase() + s.slice(1);
+		}
+		function getNumPadName(n) {
+		  const lo = n.toLowerCase();
+		  if (lo === 'dec') return 'Numpad .';
+		  if (lo === 'add') return 'Numpad +';
+		  if (lo === 'sub') return 'Numpad -';
+		  if (lo === 'mult') return 'Numpad *';
+		  if (lo === 'div') return 'Numpad /';
+		  return 'Numpad ' + firstToUpperCase(n);
+		}
+		function getKeyName(k) {
+		  const lo = k.toLowerCase();
+		  if (lo === 'commandorcontrol' || lo === 'cmdorctrl')
+			return 'Cmd/Ctrl';
+		  if (lo === 'command')
+			return 'Cmd';
+		  if (lo === 'control')
+			return 'Ctrl';
+		  if (lo === 'plus')
+			return '+';
+		  if (lo === 'return')
+			return 'Enter';
+		  if (lo === 'escape')
+			return 'Esc';
+		  if (lo.startsWith('num'))
+			return getNumPadName(k.slice(3));
+		  return firstToUpperCase(k);
+		}
+		function mapAccelerator(acc) {
+			return acc.split('+').map(getKeyName);
+		}		
 
-      const shortcutNodes = shortcuts.map(([label, keys]) => {
-        const liElem = document.createElement('li');
+		let registeredShortcuts = [];
+		try {
+		  registeredShortcuts = JSON.parse(window.process.argv.slice(-1)).reduce((arr, def) => {
+			arr.push([def.title, mapAccelerator(def.accelerators[0])]);
+			def.accelerators.slice(1).forEach(acc => arr.push(['', mapAccelerator(acc)]))
+			return arr;
+		  }, []);
+		} catch { }
 
-        const labelElem = document.createElement('div');
-        const labelTextNode = document.createTextNode(label);
-        labelElem.classList.add('label');
-        labelElem.appendChild(labelTextNode);
+		const menuShortcuts = [
+		  ['Open HTML File', ['Cmd/Ctrl', 'O']],
+		  ['Reload', ['Cmd/Ctrl', 'R']],
+		  ['Reload Ignoring Cache', ['Cmd/Ctrl', 'Shift', 'R']],
+		  ['Reload CSS Files In-place', ['Alt', 'R']],
+		];
 
-        liElem.appendChild(labelElem);
+		const shortcuts = menuShortcuts.concat(registeredShortcuts);
 
-        keys.forEach((k, idx) => {
-          const keyElem = document.createElement('div');
-          const keyTextNode = document.createTextNode(k);
-          keyElem.classList.add('key');
-          keyElem.appendChild(keyTextNode);
-          if (idx != 0) {
-            liElem.append('+');
-          }
-          liElem.appendChild(keyElem);
-        });
+		const shortcutNodes = shortcuts.map(([label, keys]) => {
+		  const liElem = document.createElement('li');
 
-        return liElem;
-      });
+		  const labelElem = document.createElement('div');
+		  const labelTextNode = document.createTextNode(label);
+		  labelElem.classList.add('label');
+		  labelElem.appendChild(labelTextNode);
 
-      shortcutNodes.forEach(node => {
-        document.getElementById('list').append(node);
-      });
+		  liElem.appendChild(labelElem);
 
-      const remote = require('electron').remote;
-      const BrowserWindow = remote.BrowserWindow;
+		  keys.forEach((k, idx) => {
+			const keyElem = document.createElement('div');
+			const keyTextNode = document.createTextNode(k);
+			keyElem.classList.add('key');
+			keyElem.appendChild(keyTextNode);
+			if (idx != 0) {
+			  liElem.append('+');
+			}
+			liElem.appendChild(keyElem);
+		  });
 
-      document.onreadystatechange = () => {
-        if (document.readyState === 'complete') {
-          document.getElementById('close-btn').addEventListener('click', () => {
-            const window = BrowserWindow.getFocusedWindow();
-            window.hide();
-          });
-        }
-      };
-    </script>
-  </body>
+		  return liElem;
+		});
+
+		shortcutNodes.forEach(node => {
+		  document.getElementById('list').append(node);
+		});
+
+		const remote = require('electron').remote;
+		const BrowserWindow = remote.BrowserWindow;
+
+		document.onreadystatechange = () => {
+		  if (document.readyState === 'complete') {
+			document.getElementById('close-btn').addEventListener('click', () => {
+			  const window = BrowserWindow.getFocusedWindow();
+			  window.hide();
+			});
+		  }
+		};
+	  </script>
+	</body>
 </html>

--- a/desktop-app/app/shortcuts.html
+++ b/desktop-app/app/shortcuts.html
@@ -1,165 +1,165 @@
 <html>
-	<head>
-	  <link rel="stylesheet" type="text/css" href="app.global.css" />
-	  <style>
-		body {
-		  background-color: #1e1e1e;
-		  color: white;
-		  display: flex;
-		  justify-content: space-between;
-		  flex-direction: column;
-		  font-family: 'Roboto', sans-serif;
-		}
-		ul {
-		  margin: 20px 50px;
-		  overflow-y: auto;
-		}
-		li {
-		  display: flex;
-		  flex-direction: row;
-		  flex-wrap: wrap;
-		  align-items: center;
-		  padding: 5px;
-		}
-		.header {
-		  font-size: 2em;
-		  display: flex;
-		  justify-content: center;
-		  margin: 100px 0 50px;
-		}
-		.label {
-		  width: 250px;
-		  font-size: large;
-		}
-		.key {
-		  display: flex;
-		  text-align: right;
-		  padding: 7px;
-		  margin: 0 10px;
-		  justify-content: center;
-		  align-items: center;
-		  font-size: large;
-		  background-color: black;
-		  border-radius: 5px;
-		  font-family: "Consolas", "Courier New", monospace;
-		  white-space: pre;
-		}
-		.btn-wrapper {
-		  display: flex;
-		  justify-content: center;
-		  background-color: transparent;
-		  padding-bottom: 50px;
-		}
-		#close-btn {
-		  font-family: 'Roboto', sans-serif;
-		  font-size: x-large;
-		  padding: 10 20 10 20px;
-		  border: 0;
-		  border-radius: 5px;
-		  background-color: black;
-		  color: white;
-		  cursor: pointer;
-		}
-	  </style>
-	</head>
-	<body>
-	  <div class="header">Keyboard Shortcuts</div>
-	  <ul id="list"></ul>
-	  <div class="btn-wrapper">
-		<button id="close-btn">Close</button>
-	  </div>
-	  <script>
-		function firstToUpperCase(s) {
-		  return s[0].toUpperCase() + s.slice(1);
-		}
-		function getNumPadName(n) {
-		  const lo = n.toLowerCase();
-		  if (lo === 'dec') return 'Numpad .';
-		  if (lo === 'add') return 'Numpad +';
-		  if (lo === 'sub') return 'Numpad -';
-		  if (lo === 'mult') return 'Numpad *';
-		  if (lo === 'div') return 'Numpad /';
-		  return 'Numpad ' + firstToUpperCase(n);
-		}
-		function getKeyName(k) {
-		  const lo = k.toLowerCase();
-		  if (lo === 'commandorcontrol' || lo === 'cmdorctrl')
-			return 'Cmd/Ctrl';
-		  if (lo === 'command')
-			return 'Cmd';
-		  if (lo === 'control')
-			return 'Ctrl';
-		  if (lo === 'plus')
-			return '+';
-		  if (lo === 'return')
-			return 'Enter';
-		  if (lo === 'escape')
-			return 'Esc';
-		  if (lo.startsWith('num'))
-			return getNumPadName(k.slice(3));
-		  return firstToUpperCase(k);
-		}
-		function mapAccelerator(acc) {
-			return acc.split('+').map(getKeyName);
-		}		
+  <head>
+    <link rel="stylesheet" type="text/css" href="app.global.css" />
+    <style>
+      body {
+        background-color: #1e1e1e;
+        color: white;
+        display: flex;
+        justify-content: space-between;
+        flex-direction: column;
+        font-family: 'Roboto', sans-serif;
+      }
+      ul {
+        margin: 20px 50px;
+		overflow-y: auto;
+      }
+      li {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        align-items: center;
+        padding: 5px;
+      }
+      .header {
+        font-size: 2em;
+        display: flex;
+        justify-content: center;
+        margin: 100px 0 50px;
+      }
+      .label {
+        width: 250px;
+        font-size: large;
+      }
+      .key {
+        display: flex;
+        text-align: right;
+        padding: 7px;
+        margin: 0 10px;
+        justify-content: center;
+        align-items: center;
+        font-size: large;
+        background-color: black;
+        border-radius: 5px;
+		font-family: "Consolas", "Courier New", monospace;
+		white-space: pre;
+      }
+      .btn-wrapper {
+        display: flex;
+        justify-content: center;
+        background-color: transparent;
+        padding-bottom: 50px;
+      }
+      #close-btn {
+        font-family: 'Roboto', sans-serif;
+        font-size: x-large;
+        padding: 10 20 10 20px;
+        border: 0;
+        border-radius: 5px;
+        background-color: black;
+        color: white;
+        cursor: pointer;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">Keyboard Shortcuts</div>
+    <ul id="list"></ul>
+    <div class="btn-wrapper">
+      <button id="close-btn">Close</button>
+    </div>
+    <script>
+      function firstToUpperCase(s) {
+        return s[0].toUpperCase() + s.slice(1);
+      }
+      function getNumPadName(n) {
+        const lo = n.toLowerCase();
+        if (lo === 'dec') return 'Numpad .';
+        if (lo === 'add') return 'Numpad +';
+        if (lo === 'sub') return 'Numpad -';
+        if (lo === 'mult') return 'Numpad *';
+        if (lo === 'div') return 'Numpad /';
+        return 'Numpad ' + firstToUpperCase(n);
+      }
+      function getKeyName(k) {
+        const lo = k.toLowerCase();
+        if (lo === 'commandorcontrol' || lo === 'cmdorctrl')
+        return 'Cmd/Ctrl';
+        if (lo === 'command')
+        return 'Cmd';
+        if (lo === 'control')
+        return 'Ctrl';
+        if (lo === 'plus')
+        return '+';
+        if (lo === 'return')
+        return 'Enter';
+        if (lo === 'escape')
+        return 'Esc';
+        if (lo.startsWith('num'))
+        return getNumPadName(k.slice(3));
+        return firstToUpperCase(k);
+      }
+      function mapAccelerator(acc) {
+        return acc.split('+').map(getKeyName);
+      }    
+	  
+      let registeredShortcuts = [];
+      try {
+        registeredShortcuts = JSON.parse(window.process.argv.slice(-1)).reduce((arr, def) => {
+        arr.push([def.title, mapAccelerator(def.accelerators[0])]);
+        def.accelerators.slice(1).forEach(acc => arr.push(['', mapAccelerator(acc)]))
+        return arr;
+        }, []);
+      } catch { }
 
-		let registeredShortcuts = [];
-		try {
-		  registeredShortcuts = JSON.parse(window.process.argv.slice(-1)).reduce((arr, def) => {
-			arr.push([def.title, mapAccelerator(def.accelerators[0])]);
-			def.accelerators.slice(1).forEach(acc => arr.push(['', mapAccelerator(acc)]))
-			return arr;
-		  }, []);
-		} catch { }
+      const menuShortcuts = [
+        ['Open HTML File', ['Cmd/Ctrl', 'O']],
+        ['Reload', ['Cmd/Ctrl', 'R']],
+        ['Reload Ignoring Cache', ['Cmd/Ctrl', 'Shift', 'R']],
+        ['Reload CSS Files In-place', ['Alt', 'R']],
+      ];
 
-		const menuShortcuts = [
-		  ['Open HTML File', ['Cmd/Ctrl', 'O']],
-		  ['Reload', ['Cmd/Ctrl', 'R']],
-		  ['Reload Ignoring Cache', ['Cmd/Ctrl', 'Shift', 'R']],
-		  ['Reload CSS Files In-place', ['Alt', 'R']],
-		];
+      const shortcuts = menuShortcuts.concat(registeredShortcuts);
 
-		const shortcuts = menuShortcuts.concat(registeredShortcuts);
+      const shortcutNodes = shortcuts.map(([label, keys]) => {
+        const liElem = document.createElement('li');
 
-		const shortcutNodes = shortcuts.map(([label, keys]) => {
-		  const liElem = document.createElement('li');
+        const labelElem = document.createElement('div');
+        const labelTextNode = document.createTextNode(label);
+        labelElem.classList.add('label');
+        labelElem.appendChild(labelTextNode);
 
-		  const labelElem = document.createElement('div');
-		  const labelTextNode = document.createTextNode(label);
-		  labelElem.classList.add('label');
-		  labelElem.appendChild(labelTextNode);
+        liElem.appendChild(labelElem);
 
-		  liElem.appendChild(labelElem);
+        keys.forEach((k, idx) => {
+          const keyElem = document.createElement('div');
+          const keyTextNode = document.createTextNode(k);
+          keyElem.classList.add('key');
+          keyElem.appendChild(keyTextNode);
+          if (idx != 0) {
+            liElem.append('+');
+          }
+          liElem.appendChild(keyElem);
+        });
 
-		  keys.forEach((k, idx) => {
-			const keyElem = document.createElement('div');
-			const keyTextNode = document.createTextNode(k);
-			keyElem.classList.add('key');
-			keyElem.appendChild(keyTextNode);
-			if (idx != 0) {
-			  liElem.append('+');
-			}
-			liElem.appendChild(keyElem);
-		  });
+        return liElem;
+      });
 
-		  return liElem;
-		});
+      shortcutNodes.forEach(node => {
+        document.getElementById('list').append(node);
+      });
 
-		shortcutNodes.forEach(node => {
-		  document.getElementById('list').append(node);
-		});
+      const remote = require('electron').remote;
+      const BrowserWindow = remote.BrowserWindow;
 
-		const remote = require('electron').remote;
-		const BrowserWindow = remote.BrowserWindow;
-
-		document.onreadystatechange = () => {
-		  if (document.readyState === 'complete') {
-			document.getElementById('close-btn').addEventListener('click', () => {
-			  const window = BrowserWindow.getFocusedWindow();
-			  window.hide();
-			});
-		  }
-		};
-	  </script>
-	</body>
+      document.onreadystatechange = () => {
+        if (document.readyState === 'complete') {
+          document.getElementById('close-btn').addEventListener('click', () => {
+            const window = BrowserWindow.getFocusedWindow();
+            window.hide();
+          });
+        }
+      };
+    </script>
+  </body>
 </html>

--- a/desktop-app/app/shortcuts.html
+++ b/desktop-app/app/shortcuts.html
@@ -84,19 +84,19 @@
       function getKeyName(k) {
         const lo = k.toLowerCase();
         if (lo === 'commandorcontrol' || lo === 'cmdorctrl')
-        return 'Cmd/Ctrl';
+          return 'Cmd/Ctrl';
         if (lo === 'command')
-        return 'Cmd';
+          return 'Cmd';
         if (lo === 'control')
-        return 'Ctrl';
+          return 'Ctrl';
         if (lo === 'plus')
-        return '+';
+          return '+';
         if (lo === 'return')
-        return 'Enter';
+          return 'Enter';
         if (lo === 'escape')
-        return 'Esc';
+          return 'Esc';
         if (lo.startsWith('num'))
-        return getNumPadName(k.slice(3));
+          return getNumPadName(k.slice(3));
         return firstToUpperCase(k);
       }
       function mapAccelerator(acc) {

--- a/desktop-app/app/shortcuts.html
+++ b/desktop-app/app/shortcuts.html
@@ -12,7 +12,7 @@
       }
       ul {
         margin: 20px 50px;
-		overflow-y: auto;
+        overflow-y: auto;
       }
       li {
         display: flex;
@@ -41,8 +41,8 @@
         font-size: large;
         background-color: black;
         border-radius: 5px;
-		font-family: "Consolas", "Courier New", monospace;
-		white-space: pre;
+        font-family: "Consolas", "Courier New", monospace;
+        white-space: pre;
       }
       .btn-wrapper {
         display: flex;

--- a/desktop-app/app/shotcut-manager/local-shortcut/electron-is-accelerator.js
+++ b/desktop-app/app/shotcut-manager/local-shortcut/electron-is-accelerator.js
@@ -1,0 +1,26 @@
+// based on https://github.com/brrd/electron-is-accelerator/blob/master/index.js
+// modified by @jjavierdguezas
+// added numpad support
+
+const modifiers = /^(Command|Cmd|Control|Ctrl|CommandOrControl|CmdOrCtrl|Alt|Option|AltGr|Shift|Super)$/;
+const keyCodes = /^([0-9A-Z)!@#$%^&*(:+<_>?~{|}";=,\-./`[\\\]']|F1*[1-9]|F10|F2[0-4]|Plus|Space|Tab|Backspace|Delete|Insert|Return|Enter|Up|Down|Left|Right|Home|End|PageUp|PageDown|Escape|Esc|VolumeUp|VolumeDown|VolumeMute|MediaNextTrack|MediaPreviousTrack|MediaStop|MediaPlayPause|PrintScreen|Num0|Num1|Num2|Num3|Num4|Num5|Num6|Num7|Num8|Num9|Numdec|Numadd|Numsub|Nummult|Numdiv)$/;
+
+export function isAccelerator (str) {
+    if (str == null || str.length === 0) return false;
+	let parts = str.split("+");
+	let keyFound = false;
+    return parts.every((val, index) => {
+        if (val == null || val === '') return false;
+        const upper = val[0].toUpperCase() + val.slice(1); 
+		const isKey = keyCodes.test(upper);
+		const isModifier = modifiers.test(upper);
+		if (isKey) {
+			// Key must be unique
+			if (keyFound) return false;
+			keyFound = true;
+		}
+		// Key is required
+		if (index === parts.length - 1 && !keyFound) return false;
+        return isKey || isModifier;
+    });
+};

--- a/desktop-app/app/shotcut-manager/local-shortcut/electron-localshortcut.js
+++ b/desktop-app/app/shotcut-manager/local-shortcut/electron-localshortcut.js
@@ -1,0 +1,182 @@
+// based on https://github.com/beakerbrowser/electron-localshortcut/blob/master/index.js
+// modified by @jjavierdguezas
+// added numpad support
+
+import {app, BrowserWindow, webContents} from 'electron';
+import {toKeyEvent} from './keyboardevent-from-electron-accelerator';
+import {isAccelerator} from './electron-is-accelerator';
+const equals = require('keyboardevents-areequal');
+
+// globals
+// =
+
+let isWatchingWCCreation = false;
+const registeredWindowWCs = new Map(); // map of webContents -> shortcuts
+
+// exported api
+// =
+
+module.exports = {
+  register,
+  unregister,
+  unregisterAll,
+  enableAll,
+  disableAll
+};
+
+function register (win, accelerator, callback) {
+  // sanity checks
+  if (win.isDestroyed()) return;
+  checkAccelerator(accelerator);
+
+  // listen to web-contents creations if needed
+  watchWCCreation();
+
+  // create shortcuts for the window
+  const windowWC = win.webContents;
+  let shortcuts = registeredWindowWCs.get(windowWC);
+  if (!shortcuts) shortcuts = startTracking(windowWC);
+
+  // add the shortcut
+  shortcuts.push({
+    eventStamp: toKeyEvent(accelerator),
+    callback,
+    enabled: true
+  });
+}
+
+function unregister (win, accelerator) {
+  // sanity checks
+  if (win.isDestroyed()) return;
+  checkAccelerator(accelerator);
+
+  const windowWC = win.webContents;
+  if (!registeredWindowWCs.has(windowWC)) {
+    return; // no shortcuts registered, abort
+  }
+
+  // remove the shortcut
+  const keyEvent = toKeyEvent(accelerator);
+  const shortcuts = registeredWindowWCs.get(windowWC);
+  const shortcutIdx = shortcuts.findIndex(shortcut => equals(shortcut.eventStamp, keyEvent));
+  if (shortcutIdx !== -1) shortcuts.splice(shortcutIdx, 1);
+
+  // stop tracking the window if done
+  if (shortcuts.length === 0) {
+    stopTracking(windowWC);
+  }
+}
+
+function unregisterAll (win) {
+  // sanity checks
+  if (win.isDestroyed()) return;
+
+  const windowWC = win.webContents;
+  if (!registeredWindowWCs.has(windowWC)) {
+    return; // no shortcuts registered, abort
+  }
+
+  // stop tracking the window
+  stopTracking(windowWC);
+}
+
+function enableAll (win) {
+  const windowWC = win.webContents;
+  const shortcuts = registeredWindowWCs.get(windowWC);
+  for (let shortcut of shortcuts) {
+    shortcut.enabled = true;
+  }
+}
+
+function disableAll (win) {
+  const windowWC = win.webContents;
+  const shortcuts = registeredWindowWCs.get(windowWC);
+  for (let shortcut of shortcuts) {
+    shortcut.enabled = false;
+  }
+}
+
+// internal methods
+// =
+
+function checkAccelerator (accelerator) {
+  if (!isAccelerator(accelerator)) {
+    throw new Error(`${accelerator} is not a valid accelerator`);
+  }
+  return true;
+}
+
+function normalizeEvent (input) {
+  const normalizedEvent = {
+    code: input.code,
+    key: input.key
+  };
+
+  for (let prop of ['alt', 'shift', 'meta']) {
+    if (typeof input[prop] !== 'undefined') {
+      normalizedEvent[`${prop}Key`] = input[prop];
+    }
+  }
+
+  if (typeof input.control !== 'undefined') {
+    normalizedEvent.ctrlKey = input.control;
+  }
+
+  return normalizedEvent;
+}
+
+function watchWCCreation () {
+  if (isWatchingWCCreation) return;
+  isWatchingWCCreation = true;
+
+  // when a new web-contents is created, register before-input-event as needed
+  app.on('web-contents-created', (e, wc) => {
+    for (let [windowWC, shortcuts] of registeredWindowWCs) {
+      if (isWindowWC(windowWC, wc)) {
+        wc.on('before-input-event', shortcuts.onBeforeInputEvent);
+      }
+    }
+  });
+}
+
+function isWindowWC (windowWC, wc) {
+  if (windowWC === wc) return true;
+  if (windowWC === wc.hostWebContents) return true;
+  return false;
+}
+
+function startTracking (windowWC) {
+  const shortcuts = [];
+  registeredWindowWCs.set(windowWC, shortcuts);
+
+  // create event handler
+  shortcuts.onBeforeInputEvent = (e, input) => {
+    if (input.type === 'keyUp') return;
+    const event = normalizeEvent(input);
+    for (let {eventStamp, callback} of shortcuts) {
+      if (equals(eventStamp, event)) {
+        callback();
+        return;
+      }
+    }
+  }
+
+  // register on all of the window's webContents
+  for (let wc of webContents.getAllWebContents()) {
+    if (isWindowWC(windowWC, wc)) {
+      wc.on('before-input-event', shortcuts.onBeforeInputEvent);
+    }
+  }
+
+  return shortcuts;
+}
+
+function stopTracking (windowWC) {
+  const shortcuts = registeredWindowWCs.get(windowWC);
+  for (let wc of webContents.getAllWebContents()) {
+    if (isWindowWC(windowWC, wc)) {
+      wc.removeListener('before-input-event', shortcuts.onBeforeInputEvent);
+    }
+  }
+  registeredWindowWCs.delete(windowWC);
+}

--- a/desktop-app/app/shotcut-manager/local-shortcut/keyboardevent-from-electron-accelerator.js
+++ b/desktop-app/app/shotcut-manager/local-shortcut/keyboardevent-from-electron-accelerator.js
@@ -1,0 +1,311 @@
+// based on https://github.com/parro-it/keyboardevent-from-electron-accelerator/blob/master/index.js
+// modified by @jjavierdguezas
+// added numpad support
+
+const modifiers = /^(CommandOrControl|CmdOrCtrl|Command|Cmd|Control|Ctrl|AltGr|Option|Alt|Shift|Super)/i;
+const keyCodes = /^(Plus|Space|Tab|Backspace|Delete|Insert|Return|Enter|Up|Down|Left|Right|Home|End|PageUp|PageDown|Escape|Esc|VolumeUp|VolumeDown|VolumeMute|MediaNextTrack|MediaPreviousTrack|MediaStop|MediaPlayPause|PrintScreen|F24|F23|F22|F21|F20|F19|F18|F17|F16|F15|F14|F13|F12|F11|F10|F9|F8|F7|F6|F5|F4|F3|F2|F1|num0|num1|num2|num3|num4|num5|num6|num7|num8|num9|numdec|numadd|numsub|nummult|numdiv|[0-9A-Z)!@#$%^&*(:+<_>?~{|}";=,\-./`[\\\]'])/i;
+const UNSUPPORTED = {};
+
+function _command(accelerator, event, modifier) {
+	if (process.platform !== 'darwin') {
+		return UNSUPPORTED;
+	}
+
+	if (event.metaKey) {
+		throw new Error('Double `Command` modifier specified.');
+	}
+
+	return {
+		event: Object.assign({}, event, {metaKey: true}),
+		accelerator: accelerator.slice(modifier.length)
+	};
+}
+
+function _super(accelerator, event, modifier) {
+	if (event.metaKey) {
+		throw new Error('Double `Super` modifier specified.');
+	}
+
+	return {
+		event: Object.assign({}, event, {metaKey: true}),
+		accelerator: accelerator.slice(modifier.length)
+	};
+}
+
+function _commandorcontrol(accelerator, event, modifier) {
+	if (process.platform === 'darwin') {
+		if (event.metaKey) {
+			throw new Error('Double `Command` modifier specified.');
+		}
+
+		return {
+			event: Object.assign({}, event, {metaKey: true}),
+			accelerator: accelerator.slice(modifier.length)
+		};
+	}
+
+	if (event.ctrlKey) {
+		throw new Error('Double `Control` modifier specified.');
+	}
+
+	return {
+		event: Object.assign({}, event, {ctrlKey: true}),
+		accelerator: accelerator.slice(modifier.length)
+	};
+}
+
+function _alt(accelerator, event, modifier) {
+	if (modifier === 'option' && process.platform !== 'darwin') {
+		return UNSUPPORTED;
+	}
+
+	if (event.altKey) {
+		throw new Error('Double `Alt` modifier specified.');
+	}
+
+	return {
+		event: Object.assign({}, event, {altKey: true}),
+		accelerator: accelerator.slice(modifier.length)
+	};
+}
+
+function _shift(accelerator, event, modifier) {
+	if (event.shiftKey) {
+		throw new Error('Double `Shift` modifier specified.');
+	}
+
+	return {
+		event: Object.assign({}, event, {shiftKey: true}),
+		accelerator: accelerator.slice(modifier.length)
+	};
+}
+
+function _control(accelerator, event, modifier) {
+	if (event.ctrlKey) {
+		throw new Error('Double `Control` modifier specified.');
+	}
+
+	return {
+		event: Object.assign({}, event, {ctrlKey: true}),
+		accelerator: accelerator.slice(modifier.length)
+	};
+}
+
+function reduceModifier({accelerator, event}, modifier) {
+	switch (modifier) {
+		case 'command':
+		case 'cmd': {
+			return _command(accelerator, event, modifier);
+		}
+
+		case 'super': {
+			return _super(accelerator, event, modifier);
+		}
+
+		case 'control':
+		case 'ctrl': {
+			return _control(accelerator, event, modifier);
+		}
+
+		case 'commandorcontrol':
+		case 'cmdorctrl': {
+			return _commandorcontrol(accelerator, event, modifier);
+		}
+
+		case 'option':
+		case 'altgr':
+		case 'alt': {
+			return _alt(accelerator, event, modifier);
+		}
+
+		case 'shift': {
+			return _shift(accelerator, event, modifier);
+		}
+
+		default:
+			console.error(modifier);
+	}
+}
+
+function reducePlus({accelerator, event}) {
+	return {
+		event,
+		accelerator: accelerator.trim().slice(1)
+	};
+}
+
+const virtualKeyCodes = {
+	0: 'Digit0',
+	1: 'Digit1',
+	2: 'Digit2',
+	3: 'Digit3',
+	4: 'Digit4',
+	5: 'Digit5',
+	6: 'Digit6',
+	7: 'Digit7',
+	8: 'Digit8',
+	9: 'Digit9',
+	'-': 'Minus',
+	'=': 'Equal',
+	Q: 'KeyQ',
+	W: 'KeyW',
+	E: 'KeyE',
+	R: 'KeyR',
+	T: 'KeyT',
+	Y: 'KeyY',
+	U: 'KeyU',
+	I: 'KeyI',
+	O: 'KeyO',
+	P: 'KeyP',
+	'[': 'BracketLeft',
+	']': 'BracketRight',
+	A: 'KeyA',
+	S: 'KeyS',
+	D: 'KeyD',
+	F: 'KeyF',
+	G: 'KeyG',
+	H: 'KeyH',
+	J: 'KeyJ',
+	K: 'KeyK',
+	L: 'KeyL',
+	';': 'Semicolon',
+	'\'': 'Quote',
+	'`': 'Backquote',
+	'/': 'Backslash',
+	Z: 'KeyZ',
+	X: 'KeyX',
+	C: 'KeyC',
+	V: 'KeyV',
+	B: 'KeyB',
+	N: 'KeyN',
+	M: 'KeyM',
+	',': 'Comma',
+	'.': 'Period',
+	'\\': 'Slash',
+	' ': 'Space'
+};
+
+function reduceKey({accelerator, event}, key) {
+	if (key.length > 1 || event.key) {
+		throw new Error(`Unvalid keycode \`${key}\`.`);
+	}
+
+	const code =
+		key.toUpperCase() in virtualKeyCodes ?
+			virtualKeyCodes[key.toUpperCase()] :
+			null;
+
+	return {
+		event: Object.assign({}, event, {key}, code ? {code} : null),
+		accelerator: accelerator.trim().slice(key.length)
+	};
+}
+
+const domKeys = Object.assign(Object.create(null), {
+	plus: 'Add',
+	space: 'Space',
+	tab: 'Tab',
+	backspace: 'Backspace',
+	delete: 'Delete',
+	insert: 'Insert',
+	return: 'Return',
+	enter: 'Return',
+	up: 'ArrowUp',
+	down: 'ArrowDown',
+	left: 'ArrowLeft',
+	right: 'ArrowRight',
+	home: 'Home',
+	end: 'End',
+	pageup: 'PageUp',
+	pagedown: 'PageDown',
+	escape: 'Escape',
+	esc: 'Escape',
+	volumeup: 'AudioVolumeUp',
+	volumedown: 'AudioVolumeDown',
+	volumemute: 'AudioVolumeMute',
+	medianexttrack: 'MediaTrackNext',
+	mediaprevioustrack: 'MediaTrackPrevious',
+	mediastop: 'MediaStop',
+	mediaplaypause: 'MediaPlayPause',
+	printscreen: 'PrintScreen'
+});
+
+// Add function keys
+for (let i = 1; i <= 24; i++) {
+	domKeys[`f${i}`] = `F${i}`;
+}
+
+for (let i = 0; i < 10; i++) {
+    domKeys[`num${i}`] = `Numpad${i}`;
+}
+
+domKeys['numdec'] = 'NumpadDecimal';
+domKeys['numadd'] = 'NumpadAdd';
+domKeys['numsub'] = 'NumpadSubtract';
+domKeys['nummult'] = 'NumpadMultiply';
+domKeys['numdiv'] = 'NumpadDivide';
+
+function reduceCode({accelerator, event}, {code, key}) {
+	if (event.code) {
+		throw new Error(`Duplicated keycode \`${key}\`.`);
+	}
+
+	return {
+		event: Object.assign({}, event, {key:getKey(key)}, code ? {code} : null),
+		accelerator: accelerator.trim().slice((key && key.length) || 0)
+	};
+}
+
+function getKey(k) {
+    if (k.startsWith('num'))
+    {
+       let s = k.slice(3);
+       if (s === 'dec') return '.';
+       if (s === 'add') return '+';
+       if (s === 'sub') return '-';
+       if (s === 'mult') return '*';
+       if (s === 'div') return '/';
+       return s;
+    }
+    return k;
+}
+
+/**
+ * This function transform an Electron Accelerator string into
+ * a DOM KeyboardEvent object.
+ *
+ * @param  {string} accelerator an Electron Accelerator string, e.g. `Ctrl+C` or `Shift+Space`.
+ * @return {object} a DOM KeyboardEvent object derivate from the `accelerator` argument.
+ */
+export function toKeyEvent(accelerator) {
+	let state = {accelerator, event: {}};
+	while (state.accelerator !== '') {
+		const modifierMatch = state.accelerator.match(modifiers);
+		if (modifierMatch) {
+			const modifier = modifierMatch[0].toLowerCase();
+			state = reduceModifier(state, modifier);
+			if (state === UNSUPPORTED) {
+				return {unsupportedKeyForPlatform: true};
+			}
+		} else if (state.accelerator.trim()[0] === '+') {
+			state = reducePlus(state);
+		} else {
+			const codeMatch = state.accelerator.match(keyCodes);
+			if (codeMatch) {
+				const code = codeMatch[0].toLowerCase();
+				if (code in domKeys) {
+					state = reduceCode(state, {
+						code: domKeys[code],
+						key: code
+					});
+				} else {
+					state = reduceKey(state, code);
+				}
+			} else {
+				throw new Error(`Unvalid accelerator: "${state.accelerator}"`);
+			}
+		}
+	}
+
+	return state.event;
+}

--- a/desktop-app/app/shotcut-manager/main-shortcut-manager.js
+++ b/desktop-app/app/shotcut-manager/main-shortcut-manager.js
@@ -1,0 +1,56 @@
+import { ipcMain, globalShortcut } from 'electron';
+import {
+    REGISTER_CHANNEL,
+    UNREGISTER_CHANNEL,
+    REGISTER_REPLY_CHANNEL,
+    UNREGISTER_REPLY_CHANNEL,
+    CLEAR_CHANNEL,
+    ShortcutDefinition,
+    validateDefinition
+} from './shared';
+
+let shortcuts: Map<string, ShortcutDefinition>;
+let mainWindow;
+
+function validate(shortcut: ShortcutDefinition, checkUnique = false) {
+    return validateDefinition(shortcut) && !(checkUnique && shortcuts.has(shortcut.id));
+}
+
+export function registerShortcut(shortcut: ShortcutDefinition): boolean {
+    if (!validate(shortcut, true)) return false;
+    const { id, accelerator } = shortcut;
+    shortcuts.set(id, shortcut);
+    return globalShortcut.register(accelerator, () => mainWindow.webContents.send(id));
+}
+
+export function unregisterShortcut(id: string): boolean {
+    if (id == null || !shortcuts.has(id)) return false;
+    const sc = shortcuts.get(id);
+    shortcuts.delete(id);
+    return globalShortcut.unregister(sc.accelerator);
+}
+
+export function getAllShortcuts(): ShortcutDefinition[] {
+    return [...shortcuts.values()];
+}
+
+export function initMainShortcutManager(mWdw) {
+    shortcuts = new Map();
+    mainWindow = mWdw;
+
+    ipcMain.on(REGISTER_CHANNEL, (event, definition: ShortcutDefinition) => {
+        const ok = registerShortcut(definition);
+        const id = definition == null ? null : definition.id;
+        event.reply(REGISTER_REPLY_CHANNEL, { ok, id });
+    });
+
+    ipcMain.on(UNREGISTER_CHANNEL, (event, id: string) => {
+        const ok = unregisterShortcut(id);
+        event.reply(UNREGISTER_REPLY_CHANNEL, { ok, id });
+    });
+
+    ipcMain.on(CLEAR_CHANNEL, () => {
+        globalShortcut.unregisterAll();
+        shortcuts.clear();
+    });
+}

--- a/desktop-app/app/shotcut-manager/renderer-shortcut-manager.js
+++ b/desktop-app/app/shotcut-manager/renderer-shortcut-manager.js
@@ -1,0 +1,55 @@
+import { ipcRenderer } from 'electron';
+import {
+    REGISTER_CHANNEL,
+    UNREGISTER_CHANNEL,
+    REGISTER_REPLY_CHANNEL,
+    UNREGISTER_REPLY_CHANNEL,
+    CLEAR_CHANNEL,
+    ShortcutDefinition,
+    validateDefinition,
+    CommunicationResponse
+} from './shared';
+
+let reg: Map<string, Function>;
+
+function validate(shortcut: ShortcutDefinition, checkUnique = false) {
+    return validateDefinition(shortcut) && !(checkUnique && reg.has(shortcut.id));
+}
+
+export function registerShortcut(definition: ShortcutDefinition, callback: Function): boolean {
+    if (!validate(definition, true) || callback == null) return false;
+    reg.set(definition.id, callback);
+    ipcRenderer.send(REGISTER_CHANNEL, definition);
+    return true;
+}
+
+export function unregisterShortcut(id: string) {
+    ipcRenderer.send(UNREGISTER_CHANNEL, id);
+}
+
+export function clearShortcuts() {
+    ipcRenderer.send(CLEAR_CHANNEL);
+    reg.forEach((_, key) => {
+        ipcRenderer.removeAllListeners(key);
+    });
+    reg.clear();
+}
+
+export function initRendererShortcutManager() {
+    reg = new Map();
+    ipcRenderer.on(REGISTER_REPLY_CHANNEL, (_, resp: CommunicationResponse) => {
+        const { ok, id } = resp;
+        if (!reg.has(id)) return;
+        if (ok)
+            ipcRenderer.on(id, reg.get(id));
+        else
+            reg.delete(id);
+    });
+
+    ipcRenderer.on(UNREGISTER_REPLY_CHANNEL, (_, resp: CommunicationResponse) => {
+        const { id } = resp;
+        if (!reg.has(id)) return;
+        ipcRenderer.removeAllListeners(id);
+    });
+}
+

--- a/desktop-app/app/shotcut-manager/renderer-shortcut-manager.js
+++ b/desktop-app/app/shotcut-manager/renderer-shortcut-manager.js
@@ -4,6 +4,7 @@ import {
     UNREGISTER_CHANNEL,
     REGISTER_REPLY_CHANNEL,
     UNREGISTER_REPLY_CHANNEL,
+    GET_ALL_CHANNEL,
     CLEAR_CHANNEL,
     ShortcutDefinition,
     validateDefinition,
@@ -25,6 +26,10 @@ export function registerShortcut(definition: ShortcutDefinition, callback: Funct
 
 export function unregisterShortcut(id: string) {
     ipcRenderer.send(UNREGISTER_CHANNEL, id);
+}
+
+export function getAllShortcuts() {
+    return ipcRenderer.invoke(GET_ALL_CHANNEL);
 }
 
 export function clearShortcuts() {

--- a/desktop-app/app/shotcut-manager/shared.js
+++ b/desktop-app/app/shotcut-manager/shared.js
@@ -2,11 +2,12 @@ export const REGISTER_CHANNEL = 'register-shortcut';
 export const UNREGISTER_CHANNEL = 'unregister-shortcut';
 export const REGISTER_REPLY_CHANNEL = 'register-shortcut-reply';
 export const UNREGISTER_REPLY_CHANNEL = 'unregister-shortcut-reply';
+export const GET_ALL_CHANNEL = 'get-all-shortcuts';
 export const CLEAR_CHANNEL = 'clear-shortcuts';
 export type ShortcutDefinition = {
     id: string,
     title: string,
-    accelerator: string
+    accelerators: string[]
 };
 export type CommunicationResponse = {
     ok: boolean,
@@ -17,5 +18,6 @@ export function validateDefinition(shortcut: ShortcutDefinition): boolean {
     return shortcut != null &&
         shortcut.id != null &&
         shortcut.title != null &&
-        shortcut.accelerator != null;
+        (shortcut.accelerators || []).length !== 0 &&
+        shortcut.accelerators.every(x => x != null);
 }

--- a/desktop-app/app/shotcut-manager/shared.js
+++ b/desktop-app/app/shotcut-manager/shared.js
@@ -1,0 +1,21 @@
+export const REGISTER_CHANNEL = 'register-shortcut';
+export const UNREGISTER_CHANNEL = 'unregister-shortcut';
+export const REGISTER_REPLY_CHANNEL = 'register-shortcut-reply';
+export const UNREGISTER_REPLY_CHANNEL = 'unregister-shortcut-reply';
+export const CLEAR_CHANNEL = 'clear-shortcuts';
+export type ShortcutDefinition = {
+    id: string,
+    title: string,
+    accelerator: string
+};
+export type CommunicationResponse = {
+    ok: boolean,
+    id: string
+};
+
+export function validateDefinition(shortcut: ShortcutDefinition): boolean {
+    return shortcut != null &&
+        shortcut.id != null &&
+        shortcut.title != null &&
+        shortcut.accelerator != null;
+}

--- a/desktop-app/package.json
+++ b/desktop-app/package.json
@@ -278,6 +278,7 @@
     "flwww": "^2.0.10",
     "history": "^4.7.2",
     "jimp": "^0.12.1",
+    "keyboardevents-areequal": "^0.2.2",
     "merge-img": "^2.1.3",
     "promise-worker": "^2.0.1",
     "pubsub.js": "^1.5.2",

--- a/desktop-app/yarn.lock
+++ b/desktop-app/yarn.lock
@@ -9611,7 +9611,7 @@ keyboardevent-from-electron-accelerator@^2.0.0:
   resolved "https://registry.yarnpkg.com/keyboardevent-from-electron-accelerator/-/keyboardevent-from-electron-accelerator-2.0.0.tgz#ace21b1aa4e47148815d160057f9edb66567c50c"
   integrity sha512-iQcmNA0M4ETMNi0kG/q0h/43wZk7rMeKYrXP7sqKIJbHkTU8Koowgzv+ieR/vWJbOwxx5nDC3UnudZ0aLSu4VA==
 
-keyboardevents-areequal@^0.2.1:
+keyboardevents-areequal@^0.2.1, keyboardevents-areequal@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/keyboardevents-areequal/-/keyboardevents-areequal-0.2.2.tgz#88191ec738ce9f7591c25e9056de928b40277194"
   integrity sha512-Nv+Kr33T0mEjxR500q+I6IWisOQ0lK1GGOncV0kWE6n4KFmpcu7RUX5/2B0EUtX51Cb0HjZ9VJsSY3u4cBa0kw==


### PR DESCRIPTION
# Overview
I wrote a piece of code that allows us to register shortcuts from the `Renderer` process and store them in the `Main`  process, all using IPC communication, so we would have a clean way of dispatching actions with shortcuts and having the list of shortcuts being used in the app at any time (which can be used in the hotkeys dialog). We can store as much shortcut information as we want to better display them in the hotkey dialog. If we move forward with this idea it could be the basis for the user to define their own shortcuts in the future.

This PR has the minimum amount of code that implements the idea.

# Things to think about
- Right now this is relying on `globalShortcut` from `electron` and because it runs in the `Main` process, the managers communicate using IPC. Maybe we can call `globalShortcut` from `remote` in the `Renderer` process and only notify `Main` in order to store the shortcut infos and let `electron` to handle the shortcut registration via its own IPC channels. I went with the custom option to have more control and make it easier to change the infrastructure in the future.
- Maybe `globalShortcut` is not the best shortcut manager (for example I couldn't get `Ctrl + -` shortcut to work) and we could use another lib in the `Renderer` process (something like [this](https://www.electronjs.org/docs/tutorial/keyboard-shortcuts#shortcuts-within-a-browserwindow))
- Maybe we should put all shortcuts registration in one method and call it just after `initRendererShortcutManager` call
- I don't know if the scroll in the hotkeys dialog looks good
