### PR TITLE
fix windows open-url

### DIFF
--- a/desktop-app/app/main.dev.js
+++ b/desktop-app/app/main.dev.js
@@ -90,6 +90,9 @@ const openUrl = url => {
  */
 
 app.on('will-finish-launching', () => {
+  if (process.platform === 'win32') {
+    urlToOpen = process.argv.filter(i => /^responsively/.test(i))[0];
+  }
   if (['win32', 'darwin'].includes(process.platform)) {
     if (process.argv.length >= 2) {
       app.setAsDefaultProtocolClient(protocol, process.execPath, [
@@ -196,8 +199,9 @@ const createWindow = async () => {
     if (urlToOpen) {
       openUrl(urlToOpen);
       urlToOpen = null;
+    } else {
+      mainWindow.show();
     }
-    mainWindow.show();
   });
 
   ipcMain.on('http-auth-promt-response', (event, ...args) => {


### PR DESCRIPTION
I believe I have fixed `open-url` feature on `Windows`. I have tested on both `Windows` and `Mac`. 
And this is related https://github.com/manojVivek/responsively-app/issues/155
Fix https://github.com/manojVivek/responsively-app/issues/155
Please let me know if I am missing something or something can be improved.