### PR TITLE
Fix ugly global scrollbar in hotkeys dialog

### DIFF
--- a/desktop-app/app/shortcuts.html
+++ b/desktop-app/app/shortcuts.html
@@ -13,6 +13,7 @@
       ul {
         margin: 20px 50px;
         overflow-y: auto;
+        max-height: 38vh;
       }
       li {
         display: flex;


### PR DESCRIPTION
This only happens in the production build 🤷🏻‍♂️

Before:
![image](https://user-images.githubusercontent.com/13673443/84589536-7ce06c80-ae2f-11ea-9c98-4d6a87ecf1e2.png)

After this fix:
![image](https://user-images.githubusercontent.com/13673443/84589586-f9734b00-ae2f-11ea-9b74-c77eb11de181.png)

- Fix: set `max-height` property to `ul` inside `shortcuts.html`