### PR TITLE
Drawer shrinking in horizontal layout

### DIFF
--- a/desktop-app/app/components/DevicesPreviewer/style.module.css
+++ b/desktop-app/app/components/DevicesPreviewer/style.module.css
@@ -3,7 +3,7 @@
   flex: 1;
   height: 100%;
   width: 100%;
-  overflow: scroll;
+  overflow: auto;
   flex-direction: column;
 }
 
@@ -17,7 +17,7 @@
 
 .devicesContainer {
   display: flex;
-  padding-bottom: 50px;
+  padding-bottom: 100px;
 }
 
 .tab {

--- a/desktop-app/app/components/Drawer/styles.css
+++ b/desktop-app/app/components/Drawer/styles.css
@@ -7,6 +7,7 @@
 
 .drawer.open {
   width: 290px;
+  flex-shrink: 0;
   box-shadow: 5px 7px 5px 0px rgba(0, 0, 0, 0.75);
   margin: 0 10px 0 0;
   padding: 5px 5px 0 0;

--- a/desktop-app/app/containers/Browser/index.js
+++ b/desktop-app/app/containers/Browser/index.js
@@ -29,6 +29,7 @@ const Browser = ({browser}) => {
             flex: 1,
             height: '100%',
             flexDirection: 'column',
+            overflow: 'hidden',
           }}
         >
           <DevicePreviewerContainer />


### PR DESCRIPTION
Made the drawer not shrinkable so it's still usable in horizontal layout.

#### Few other fixes: 

- increase the bottom padding on the devices container because it was really close to the new bottom app bar
- change overflow from `scroll`to `auto` on the devices container so the scrollbar only shows up when needed


fix #225 