### PR TITLE
Fix horizontal scrolling

### DIFF
--- a/desktop-app/app/app.global.css
+++ b/desktop-app/app/app.global.css
@@ -79,13 +79,26 @@ a:hover {
   cursor: pointer;
 }
 
+.react-tabs {
+  position: sticky;
+  left: 0;
+  top: 0;
+  margin-bottom: 10px;
+  z-index: 4;
+  background-color: #1e1e1e;
+}
+
 .react-tabs__tab {
   display: flex;
   align-items: center;
+  flex-shrink: 0;
+  bottom: unset;
 }
 
 .react-tabs__tab-list {
   display: flex;
+  margin-bottom: 0;
+  overflow: auto;
 }
 
 .spin::before {

--- a/desktop-app/app/components/Header/style.module.css
+++ b/desktop-app/app/components/Header/style.module.css
@@ -1,5 +1,5 @@
 .header {
-  width: calc(100vw - 50px);
+  width: 100%;
   padding: 20px 0 5px;
   background: #252526;
   box-shadow: 0 3px 5px rgba(0, 0, 0, 0.35);

--- a/desktop-app/app/containers/Browser/index.js
+++ b/desktop-app/app/containers/Browser/index.js
@@ -19,7 +19,9 @@ const Browser = ({browser}) => {
         style={{
           display: 'flex',
           flexDirection: 'row',
-          height: '100%',
+          height: 0,
+          flexGrow: 1,
+          flexBasis: 0,
         }}
       >
         <DrawerContainer />

--- a/desktop-app/app/layout.css
+++ b/desktop-app/app/layout.css
@@ -7,6 +7,7 @@
 }
 
 .iconColumn {
+  flex-shrink: 0;
   width: 50px;
   height: 100%;
   display: flex;
@@ -17,8 +18,10 @@
 }
 
 .contentColumn {
-  width: calc(100vw - 50px);
   height: 100%;
   display: flex;
   flex-direction: column;
+  flex-grow: 1;
+  overflow: hidden;
+  flex-basis: 0;
 }


### PR DESCRIPTION
Prevent the main content div from growing more than its container and thus hiding the scrollbar behind the status bar.

I also made the devices tabs scrollable, they were shrinking and became ugly on small screen.


fix #233 