### PR TITLE
Fix animation when opening the Drawer

### DIFF
--- a/desktop-app/app/components/Drawer/styles.css
+++ b/desktop-app/app/components/Drawer/styles.css
@@ -1,16 +1,16 @@
 .drawer {
-  width: 0;
+  width: 290px;
   overflow: hidden;
-  transition: width 0.2s;
+  transition: margin-left 0.2s;
   background: #252526;
+  margin: 0 10px 0 -290px;
+  padding: 5px 5px 0 5px;
 }
 
 .drawer.open {
-  width: 290px;
+  margin-left: 0;
   flex-shrink: 0;
   box-shadow: 5px 7px 5px 0px rgba(0, 0, 0, 0.75);
-  margin: 0 10px 0 0;
-  padding: 5px 5px 0 0;
 }
 
 .contentContainer {

--- a/desktop-app/app/containers/Browser/index.js
+++ b/desktop-app/app/containers/Browser/index.js
@@ -20,6 +20,7 @@ const Browser = ({browser}) => {
           display: 'flex',
           flexDirection: 'row',
           height: '100%',
+          overflowX: 'hidden',
         }}
       >
         <DrawerContainer />


### PR DESCRIPTION
Previously, width was used in animation, this caused strange animation when opening the Drawer.

This solution uses the property of margin and achieves smoother animation.