### PR TITLE
Validate the extension id 

### DIFF
--- a/desktop-app/app/components/ExtensionsManager/index.js
+++ b/desktop-app/app/components/ExtensionsManager/index.js
@@ -54,10 +54,15 @@ export default function ExtensionsManager({triggerNavigationReload}) {
     if (loading) {
       return;
     }
+    // validate the extension id.
+    if (!validateExtensionId(extensionId)) {
+      setErrorMessage('Only lowercase alphabets are allowed.');
+      setLoading(false);
+      return;
+    }
 
     setLoading(true);
     setErrorMessage('');
-
     try {
       await ipcRenderer.invoke('install-extension', extensionId);
       setExtensions(getInstalledExtensions());
@@ -98,6 +103,8 @@ export default function ExtensionsManager({triggerNavigationReload}) {
 
     setExtensionId(localExtensionPath);
   };
+
+  const validateExtensionId = extensionId => extensionId.match(/^[a-z]+$/);
 
   return (
     <>

--- a/desktop-app/app/components/ExtensionsManager/index.js
+++ b/desktop-app/app/components/ExtensionsManager/index.js
@@ -56,9 +56,7 @@ export default function ExtensionsManager({triggerNavigationReload}) {
     }
     // validate the extension id.
     if (!validateExtensionId(extensionId)) {
-      setErrorMessage(
-        'Only lowercase alphabets are allowed with maximum length of 32 chars.'
-      );
+      setErrorMessage('Extension Id must have 32 lower case alphabets');
       setLoading(false);
       return;
     }

--- a/desktop-app/app/components/ExtensionsManager/index.js
+++ b/desktop-app/app/components/ExtensionsManager/index.js
@@ -56,7 +56,9 @@ export default function ExtensionsManager({triggerNavigationReload}) {
     }
     // validate the extension id.
     if (!validateExtensionId(extensionId)) {
-      setErrorMessage('Only lowercase alphabets are allowed.');
+      setErrorMessage(
+        'Only lowercase alphabets are allowed with maximum length of 32 chars.'
+      );
       setLoading(false);
       return;
     }
@@ -104,7 +106,8 @@ export default function ExtensionsManager({triggerNavigationReload}) {
     setExtensionId(localExtensionPath);
   };
 
-  const validateExtensionId = extensionId => extensionId.match(/^[a-z]+$/);
+  const validateExtensionId = extensionId =>
+    extensionId.match(/^[a-z]+$/) && extensionId.length <= 32;
 
   return (
     <>

--- a/desktop-app/app/components/ExtensionsManager/index.js
+++ b/desktop-app/app/components/ExtensionsManager/index.js
@@ -105,7 +105,7 @@ export default function ExtensionsManager({triggerNavigationReload}) {
   };
 
   const validateExtensionId = extensionId =>
-    (extensionId.match(/^[a-z]+$/) && extensionId.length <= 32) ||
+    (extensionId.match(/^[a-z]+$/) && extensionId.length === 32) ||
     /[<>:"/\\|?]/.test(extensionId);
 
   return (

--- a/desktop-app/app/components/ExtensionsManager/index.js
+++ b/desktop-app/app/components/ExtensionsManager/index.js
@@ -56,7 +56,7 @@ export default function ExtensionsManager({triggerNavigationReload}) {
     }
     // validate the extension id.
     if (!validateExtensionId(extensionId)) {
-      setErrorMessage('Extension Id must have 32 lower case alphabets');
+      setErrorMessage('Please enter a valid extension ID');
       setLoading(false);
       return;
     }
@@ -105,7 +105,8 @@ export default function ExtensionsManager({triggerNavigationReload}) {
   };
 
   const validateExtensionId = extensionId =>
-    extensionId.match(/^[a-z]+$/) && extensionId.length <= 32;
+    (extensionId.match(/^[a-z]+$/) && extensionId.length <= 32) ||
+    /[<>:"/\\|?]/.test(extensionId);
 
   return (
     <>


### PR DESCRIPTION
**Changes**
 - Validate the extension id (allowing only lowercase characters), once the user presses enter or click on Add button.
 - Shows the error message if the input is invalid.

Fixes https://github.com/manojVivek/responsively-app/issues/240


![Screen Shot 2020-07-07 at 10 16 23 PM](https://user-images.githubusercontent.com/21375014/86879800-924c5d80-c0a0-11ea-9c9b-48ace47e44e7.png)
