### PR TITLE
fix: Solves zoom toolbar being hidden behind the devices tabs

### DIFF
--- a/desktop-app/app/app.global.css
+++ b/desktop-app/app/app.global.css
@@ -82,7 +82,7 @@ a:hover {
 .react-tabs {
   position: sticky;
   left: 0;
-  top: 5px;
+  top: 0;
   margin-bottom: 10px;
   z-index: 4;
   background-color: #1e1e1e;

--- a/desktop-app/app/app.global.css
+++ b/desktop-app/app/app.global.css
@@ -82,7 +82,7 @@ a:hover {
 .react-tabs {
   position: sticky;
   left: 0;
-  top: 0;
+  top: 5px;
   margin-bottom: 10px;
   z-index: 4;
   background-color: #1e1e1e;

--- a/desktop-app/app/components/Header/style.module.css
+++ b/desktop-app/app/components/Header/style.module.css
@@ -3,7 +3,7 @@
   padding: 20px 0 5px;
   background: #252526;
   box-shadow: 0 3px 5px rgba(0, 0, 0, 0.35);
-  z-index: 2;
+  z-index: 5;
 }
 
 .darkToast {


### PR DESCRIPTION
**Summary**

When the devices are on maximized mode the zoom controls are hidden behind the tabs

**Current behavior**

<img width="931" alt="Screen Shot 2020-07-16 at 18 43 19" src="https://user-images.githubusercontent.com/1605931/87725758-42eae900-c794-11ea-9cce-4a4703ad2fd1.png">

**With fixes applied**

<img width="912" alt="Screen Shot 2020-07-16 at 18 51 22" src="https://user-images.githubusercontent.com/1605931/87726460-6cf0db00-c795-11ea-8a69-cb4633a540e0.png">

Edit:

Just saw that this was reported a few days ago and already assigned to someone else. It's ok if you want to discard my PR.

Closes #313  