### PR TITLE
feat(zoomLevel): remember zoom level

### DIFF
--- a/desktop-app/app/containers/Root.js
+++ b/desktop-app/app/containers/Root.js
@@ -87,7 +87,11 @@ export default class Root extends Component<Props> {
     document.addEventListener('wheel', this.onWheel);
 
     registerShortcut(
-      {id: 'ZoomIn', title: 'Zoom In', accelerators: ['mod+=', 'mod+shift+=']},
+      {
+        id: 'ZoomIn',
+        title: 'Zoom In',
+        accelerators: ['mod+=', 'mod++', 'mod+shift+='],
+      },
       () => {
         store.dispatch(onZoomChange(store.getState().browser.zoomLevel + 0.1));
       },
@@ -224,12 +228,16 @@ export default class Root extends Component<Props> {
     );
   };
 
-  onWheel = (e) => {
+  onWheel = e => {
     if (e.ctrlKey) {
-      const {store} = this.props
-      store.dispatch(onZoomChange(store.getState().browser.zoomLevel + (e.deltaY < 0 ? 0.1 : -0.1)));
+      const {store} = this.props;
+      store.dispatch(
+        onZoomChange(
+          store.getState().browser.zoomLevel + (e.deltaY < 0 ? 0.1 : -0.1)
+        )
+      );
     }
-  }
+  };
 
   render() {
     const {store, history} = this.props;

--- a/desktop-app/app/reducers/browser.js
+++ b/desktop-app/app/reducers/browser.js
@@ -112,6 +112,7 @@ type UserPreferenceType = {
   drawerState: boolean,
   devToolsOpenMode: DevToolsOpenModeType,
   deviceOutlineStyle: string,
+  zoomLevel: number,
 };
 
 type FilterFieldType = FILTER_FIELDS.OS | FILTER_FIELDS.DEVICE_TYPE;
@@ -237,7 +238,7 @@ export default function browser(
       ? getLastOpenedAddress()
       : getHomepage(),
     currentPageMeta: {},
-    zoomLevel: 0.6,
+    zoomLevel: _getUserPreferences().zoomLevel || 0.6,
     previousZoomLevel: null,
     scrollPosition: {x: 0, y: 0},
     navigatorStatus: {backEnabled: false, forwardEnabled: false},
@@ -290,6 +291,10 @@ export default function browser(
       saveHomepage(homepage);
       return {...state, homepage};
     case NEW_ZOOM_LEVEL:
+      _setUserPreferences({
+        ...state.userPreferences,
+        zoomLevel: action.zoomLevel,
+      });
       return {...state, zoomLevel: action.zoomLevel};
     case NEW_SCROLL_POSITION:
       return {...state, scrollPosition: action.scrollPosition};


### PR DESCRIPTION
- **remember zoom level**

![Screen Shot 2020-07-16 at 11 09 13 PM](https://user-images.githubusercontent.com/1315054/87744660-09c56f80-c7ba-11ea-9dfc-9b09b35961a0.png)

- **add zoom level increment shortcut**

In Mac the shortcut is `Command` + `+`. The same shortcut for decrement already exists (`Command` + `-`).

Closes #320