### PR TITLE
fix(desktop-app): on mobile devices hide scrollbar on all elements

### DIFF
--- a/desktop-app/app/components/WebView/index.js
+++ b/desktop-app/app/components/WebView/index.js
@@ -488,7 +488,7 @@ class WebView extends Component {
   hideScrollbar = () => {
     this.webviewRef.current.insertCSS(
       `
-        body::-webkit-scrollbar {
+        ::-webkit-scrollbar {
           display: none;
         }
         `


### PR DESCRIPTION
As suggested on issue #255 comment https://github.com/manojVivek/responsively-app/issues/255#issuecomment-665766060 a better approach to hiding the scrollbar on mobile devices is to hide it on all elements.

